### PR TITLE
Update headers in RpcHttp to <string, string>

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -348,7 +348,7 @@ message RpcException {
 message RpcHttp {
   string method = 1;
   string url = 2; 
-  map<string,TypedData> headers = 3;
+  map<string,string> headers = 3;
   TypedData body = 4;
   map<string,string> params = 10;
   string status_code = 12;


### PR DESCRIPTION
Http headers can only be valid Ascii characters. Language workers and Functions Host need to handle converting other types of values to strings before sending message over grpc.

[Http RFC](https://tools.ietf.org/html/rfc2616#section-4.2)