### PR TITLE
Add support to reload environment variables

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -66,9 +66,9 @@ message StreamingMessage {
     // Worker logs a message back to the host
     RpcLog rpc_log = 2;
 
-    FunctionEnvironmentRequest function_environment_load_request = 25;
+    FunctionEnvironmentLoadRequest function_environment_load_request = 25;
 
-    FunctionEnvironmentResponse function_environment_load_response = 26;
+    FunctionEnvironmentLoadResponse function_environment_load_response = 26;
   }
 }
 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -66,9 +66,9 @@ message StreamingMessage {
     // Worker logs a message back to the host
     RpcLog rpc_log = 2;
 
-    FunctionEnvironmentReLoadRequest function_environment_load_request = 25;
+    FunctionEnvironmentReLoadRequest function_environment_reload_request = 25;
 
-    FunctionEnvironmentReLoadResponse function_environment_load_response = 26;
+    FunctionEnvironmentReLoadResponse function_environment_reload_response = 26;
   }
 }
 
@@ -184,12 +184,12 @@ message WorkerStatusRequest{
 message WorkerStatusResponse {
 }
 
-message FunctionEnvironmentLoadRequest {
+message FunctionEnvironmentReLoadRequest {
   // Environment variables from the current process
   map<string, string> environment_variables = 1;
 }
 
-message FunctionEnvironmentLoadResponse {
+message FunctionEnvironmentReLoadResponse {
   // Status of the response
   StatusResult result = 3;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -66,9 +66,9 @@ message StreamingMessage {
     // Worker logs a message back to the host
     RpcLog rpc_log = 2;
 
-    FunctionEnvironmentLoadRequest function_environment_load_request = 25;
+    FunctionEnvironmentReLoadRequest function_environment_load_request = 25;
 
-    FunctionEnvironmentLoadResponse function_environment_load_response = 26;
+    FunctionEnvironmentReLoadResponse function_environment_load_response = 26;
   }
 }
 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -65,6 +65,10 @@ message StreamingMessage {
 
     // Worker logs a message back to the host
     RpcLog rpc_log = 2;
+
+    FunctionEnvironmentRequest function_environment_load_request = 25;
+
+    FunctionEnvironmentResponse function_environment_load_response = 26;
   }
 }
 
@@ -178,6 +182,16 @@ message WorkerStatusRequest{
 
 // NOT USED
 message WorkerStatusResponse {
+}
+
+message FunctionEnvironmentLoadRequest {
+  // Environment variables from the current process
+  map<string, string> environment_variables = 1;
+}
+
+message FunctionEnvironmentLoadResponse {
+  // Status of the response
+  StatusResult result = 3;
 }
 
 // Host tells the worker to load a Function


### PR DESCRIPTION
Added new message to support reloading of environment variables. This message is specifically used during specialization when functions runtime starts a language worker in place holder mode and then assigns to an app at a later point in time.