### PR TITLE
Adding dataType to BindingInfo

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -301,13 +301,20 @@ message BindingInfo {
       inout = 2;
     }
 
+    // Indicates the type of the data for the binding
+    enum DataType {
+      string = 0;
+      binary = 1;
+      stream = 2;
+    }
+
   // Type of binding (e.g. HttpTrigger)
   string type = 2;
 
   // Direction of the given binding
   Direction direction = 3;
 
-  string dataType = 4;
+  DataType dataType = 4;
 }
 
 // Used to send logs back to the Host 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -314,7 +314,7 @@ message BindingInfo {
   // Direction of the given binding
   Direction direction = 3;
 
-  DataType dataType = 4;
+  DataType data_type = 4;
 }
 
 // Used to send logs back to the Host 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -307,7 +307,7 @@ message BindingInfo {
   // Direction of the given binding
   Direction direction = 3;
 
-  TypedData dataType = 4;
+  string dataType = 4;
 }
 
 // Used to send logs back to the Host 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -306,6 +306,8 @@ message BindingInfo {
 
   // Direction of the given binding
   Direction direction = 3;
+
+  TypedData dataType = 4;
 }
 
 // Used to send logs back to the Host 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -303,10 +303,10 @@ message BindingInfo {
 
     // Indicates the type of the data for the binding
     enum DataType {
-      string = 0;
-      binary = 1;
-      stream = 2;
-      undefined = 3;
+      undefined = 0;
+      string = 1;
+      binary = 2;
+      stream = 3;
     }
 
   // Type of binding (e.g. HttpTrigger)

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -306,6 +306,7 @@ message BindingInfo {
       string = 0;
       binary = 1;
       stream = 2;
+      undefined = 3;
     }
 
   // Type of binding (e.g. HttpTrigger)

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -314,7 +314,9 @@ message BindingInfo {
   // Direction of the given binding
   Direction direction = 3;
 
-  DataType dataType = 4;
+  bool hasDataType = 4;
+
+  DataType dataType = 5;
 }
 
 // Used to send logs back to the Host 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -314,9 +314,7 @@ message BindingInfo {
   // Direction of the given binding
   Direction direction = 3;
 
-  bool hasDataType = 4;
-
-  DataType dataType = 5;
+  DataType dataType = 4;
 }
 
 // Used to send logs back to the Host 


### PR DESCRIPTION
For issue https://github.com/Azure/azure-functions-host/issues/3921. Needed to implement https://github.com/Azure/azure-functions-python-worker/issues/66. 

Example queue trigger
```
def main(msg) -> None
```
above function defaults to converting msg to type QueueMessage defined in [azure-functions-python-library](https://github.com/Azure/azure-functions-python-library)

If user wants to receive msg as a String, dataType in function.json will be set to String