### PR TITLE
Added identity folder and ClaimsIdentityRpc.proto.

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -10,7 +10,7 @@ option go_package ="github.com/Azure/azure-functions-go-worker/internal/rpc";
 package AzureFunctionsRpcMessages;
 
 import "google/protobuf/duration.proto";
-import "deps/IdentityRpc.proto";
+import "identity/ClaimsIdentityRpc.proto";
 
 // Interface exported by the server.
 service FunctionRpc {
@@ -380,5 +380,5 @@ message RpcHttp {
   map<string,string> query = 15;
   bool enable_content_negotiation= 16;
   TypedData rawBody = 17;
-  repeated RpcIdentity identities = 18;
+  repeated RpcClaimsIdentity identities = 18;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -10,6 +10,7 @@ option go_package ="github.com/Azure/azure-functions-go-worker/internal/rpc";
 package AzureFunctionsRpcMessages;
 
 import "google/protobuf/duration.proto";
+import "deps/IdentityRpc.proto";
 
 // Interface exported by the server.
 service FunctionRpc {
@@ -379,4 +380,5 @@ message RpcHttp {
   map<string,string> query = 15;
   bool enable_content_negotiation= 16;
   TypedData rawBody = 17;
+  repeated RpcIdentity identities = 18;
 }

--- a/src/proto/deps/IdentityRpc.proto
+++ b/src/proto/deps/IdentityRpc.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+// protobuf vscode extension: https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3
+
+// Light-weight representation of a .NET System.Security.Claims.ClaimsIdentity object.
+// This is the same serialization as found in EasyAuth, and needs to be kept in sync with
+// its ClaimsIdentitySlim definition.
+message RpcIdentity {
+  string authentication_type = 1;
+  string name_claim_type = 2;
+  string role_claim_type = 3;
+  repeated RpcClaim claims = 4;
+}
+
+// Light-weight representation of a .NET System.Security.Claims.Claim object.
+// This is the same serialization as found in EasyAuth, and needs to be kept in sync with
+// its ClaimSlim definition.
+message RpcClaim {
+  string value = 1;
+  string type = 2;
+}

--- a/src/proto/identity/ClaimsIdentityRpc.proto
+++ b/src/proto/identity/ClaimsIdentityRpc.proto
@@ -3,8 +3,9 @@ syntax = "proto3";
 
 // Light-weight representation of a .NET System.Security.Claims.ClaimsIdentity object.
 // This is the same serialization as found in EasyAuth, and needs to be kept in sync with
-// its ClaimsIdentitySlim definition.
-message RpcIdentity {
+// its ClaimsIdentitySlim definition, as seen in the WebJobs extension:
+// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimsIdentitySlim.cs
+message RpcClaimsIdentity {
   string authentication_type = 1;
   string name_claim_type = 2;
   string role_claim_type = 3;
@@ -13,7 +14,8 @@ message RpcIdentity {
 
 // Light-weight representation of a .NET System.Security.Claims.Claim object.
 // This is the same serialization as found in EasyAuth, and needs to be kept in sync with
-// its ClaimSlim definition.
+// its ClaimSlim definition, as seen in the WebJobs extension:
+// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimSlim.cs
 message RpcClaim {
   string value = 1;
   string type = 2;


### PR DESCRIPTION
Adds definitions for ClaimsPrincipal binding on RpcHttp. New message definitions are separated into their own subfolder which can be used for other additional definitions going forward.