### PR TITLE
Allow same-site=none property in cookie

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -431,11 +431,12 @@ message RpcException {
 
 // Http cookie type. Note that only name and value are used for Http requests
 message RpcHttpCookie {
-  // Enum that lets servers require that a cookie shouoldn't be sent with cross-site requests
+  // Enum that lets servers require that a cookie shouldn't be sent with cross-site requests
   enum SameSite {
       None = 0;
       Lax = 1;
       Strict = 2;
+      ExplicitNone = 3;
   }
 
   // Cookie name


### PR DESCRIPTION
Expose option to set `same-site=none` in an http cookie

Addresses https://github.com/Azure/azure-functions-host/issues/4890

Adds ability for out-of-proc workers to explicitly set "SameSite=None" (details [here](https://blog.chromium.org/2019/10/developers-get-ready-for-new.html))

Because we already named our default "None" (which actually means "unspecified"), the new property is called "ExplicitNone"

Functions Host PR here: https://github.com/Azure/azure-functions-host/pull/5757
Node.js worker PR here: https://github.com/Azure/azure-functions-nodejs-worker/pull/286