### PR TITLE
Add parent_ fields in TraceContext

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -293,6 +293,19 @@ message RpcTraceContext {
 
 	// This corresponds to Activity.Current?.Tags
 	map<string, string> attributes = 3;
+
+  // This corresponds to Activity.Current?.ParentId
+  string parent_trace_id = 4;
+
+  // This corresponds to Activity.Current?.TraceStateString for now
+  // This is a future proof field in case if .ParentTraceStateString is
+  // introduced in the .NET SDK
+  string parent_trace_state = 5;
+
+  // This corresponds to Activity.Current?.Tags for now
+  // This is a future proof field in case if .ParentTags is introduced in
+  // the .NET SDK
+  map<string, string> parent_attributes = 6;
 }
 
 // Host sends retry context for a function invocation


### PR DESCRIPTION
### Description

The trace_parent field currently passed into language worker has an mutated span-id. In order to support application insight to build an precise application map, the parent_trace_id also needs to be passed to the worker.

### Issue Repro
1. Use Postman to send a request to function host with the **traceparent** header **00-4bf92f3577b34da6a3ce929d0e0e4736-5fd358d59f88ce45-01**. The **original span id (third section in trace parent)** is **5fd358d59f88ce45**
2. The SDK creates a new span updates the **span id** to **9ea20015365c0e40**
3. Now the **Activity.Current?.Id** field no longer have the parent span information.
4. Worker receives the **trace_parent**, but it no longer contains the parent span id
5. Application insight fails to generate the application map

![image](https://user-images.githubusercontent.com/48038149/111398003-c80a0300-867f-11eb-96e3-5e93fcfb87af.png)

/cc: @AnatoliB @brettsam @lzchen @mhoeger @vrdmr 