### PR TITLE
Add worker indexing message types to protobuf

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -75,6 +75,11 @@ message StreamingMessage {
     // Ask the worker to close any open shared memory resources for a given invocation
     CloseSharedMemoryResourcesRequest close_shared_memory_resources_request = 27;
     CloseSharedMemoryResourcesResponse close_shared_memory_resources_response = 28;
+
+    // Worker indexing message types
+    WorkerFunctionMetadataRequest worker_function_metadata_request = 29;
+    WorkerFunctionMetadataResponse worker_function_metadata_response = 30;
+    WorkerFunctionMetadata worker_function_metadata = 31;
   }
 }
 
@@ -260,6 +265,51 @@ message RpcFunctionMetadata {
 
   // Is set to true for proxy
   bool is_proxy = 7;
+}
+
+// Host tells worker it is ready to receive metadata
+message WorkerFunctionMetadataRequest {
+  // base directory for function app
+  string directory = 1;
+}
+
+// Worker sends function metadata back to host
+message WorkerFunctionMetadataResponse {
+  // list of function indexing responses
+  repeated WorkerFunctionMetadata results = 1;
+
+  // status of overall metadata request
+  StatusResult overall_status = 2;
+}
+
+// Message type that holds function metadata information
+message WorkerFunctionMetadata {
+  // function name
+  string name = 4;
+
+  // base directory for the Function
+  string directory = 1;
+
+  // Script file specified
+  string script_file = 2;
+
+  // Entry point specified
+  string entry_point = 3;
+
+  // Function id
+  string id = 11;
+
+  // Bindings info
+  repeated string bindings = 6;
+
+  // Is set to true for proxy
+  bool is_proxy = 7;
+
+  // Function indexing status
+  StatusResult status = 8;
+
+  // Function language
+  string language = 9;
 }
 
 // Host requests worker to invoke a Function

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -77,9 +77,8 @@ message StreamingMessage {
     CloseSharedMemoryResourcesResponse close_shared_memory_resources_response = 28;
 
     // Worker indexing message types
-    WorkerFunctionMetadataRequest worker_function_metadata_request = 29;
-    WorkerFunctionMetadataResponse worker_function_metadata_response = 30;
-    WorkerFunctionMetadata worker_function_metadata = 31;
+    FunctionsMetadataRequest functions_metadata_request = 29;
+    FunctionMetadataResponses function_metadata_responses = 30;
   }
 }
 
@@ -265,51 +264,30 @@ message RpcFunctionMetadata {
 
   // Is set to true for proxy
   bool is_proxy = 7;
-}
-
-// Host tells worker it is ready to receive metadata
-message WorkerFunctionMetadataRequest {
-  // base directory for function app
-  string directory = 1;
-}
-
-// Worker sends function metadata back to host
-message WorkerFunctionMetadataResponse {
-  // list of function indexing responses
-  repeated WorkerFunctionMetadata results = 1;
-
-  // status of overall metadata request
-  StatusResult overall_status = 2;
-}
-
-// Message type that holds function metadata information
-message WorkerFunctionMetadata {
-  // function name
-  string name = 4;
-
-  // base directory for the Function
-  string directory = 1;
-
-  // Script file specified
-  string script_file = 2;
-
-  // Entry point specified
-  string entry_point = 3;
-
-  // Function id
-  string id = 11;
-
-  // Bindings info
-  repeated string bindings = 6;
-
-  // Is set to true for proxy
-  bool is_proxy = 7;
 
   // Function indexing status
   StatusResult status = 8;
 
   // Function language
   string language = 9;
+
+  // Raw binding info
+  repeated string raw_bindings = 10;
+}
+
+// Host tells worker it is ready to receive metadata
+message FunctionsMetadataRequest {
+  // base directory for function app
+  string directory = 1;
+}
+
+// Worker sends function metadata back to host
+message FunctionMetadataResponses {
+  // list of function indexing responses
+  repeated FunctionLoadRequest results = 1;
+
+  // status of overall metadata request
+  StatusResult overall_status = 2;
 }
 
 // Host requests worker to invoke a Function

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -278,7 +278,7 @@ message RpcFunctionMetadata {
 // Host tells worker it is ready to receive metadata
 message FunctionsMetadataRequest {
   // base directory for function app
-  string directory = 1;
+  string function_app_directory = 1;
 }
 
 // Worker sends function metadata back to host


### PR DESCRIPTION
`FunctionsMetadataRequest`
> Sends the function app directory to the worker.

`FunctionMetadataResponses`
> Includes a list of `FunctionLoadRequest` messages and an overall `StatusResult` attribute.