### PR TITLE
Update RpcFunctionMetadata with more properties

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -271,8 +271,14 @@ message RpcFunctionMetadata {
   // Function language
   string language = 9;
 
-  // Raw binding info
+  // Raw binding info: string of jsonified binding metadata. One string = one binding
   repeated string raw_bindings = 10;
+
+  // Retry Options: string representation of JObject retry options (maxRetryCount, intervals, etc.)
+  string retry_options = 11;
+
+  // Configuration Source: string representation of JToken configuration source property in function metadata
+  string config_source = 12;
 }
 
 // Host tells worker it is ready to receive metadata


### PR DESCRIPTION
Host needs RetryOptions and configuration source information to populate FunctionMetadata, so two more properties have been added to RpcFunctionMetadata to convey this information.

Some clarifying comments have also been added to RpcFunctionMetadata that specify what the attributes are supposed to contain.