### PR TITLE
Added useDefaultMetadataIndexing field to FunctionMetadataResponses

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -282,9 +282,9 @@ message FunctionsMetadataRequest {
 }
 
 // Worker sends function metadata back to host
-message FunctionMetadataResponses {
+message FunctionMetadataResponse {
   // list of function indexing responses
-  repeated FunctionLoadRequest function_load_requests_results = 1;
+  repeated RpcFunctionMetadata function_load_requests_results = 1;
 
   // status of overall metadata request
   StatusResult result = 2;

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -288,6 +288,9 @@ message FunctionMetadataResponses {
 
   // status of overall metadata request
   StatusResult result = 2;
+
+  // if set to true then host will perform indexing
+  bool useDefaultMetadataIndexing = 3;
 }
 
 // Host requests worker to invoke a Function

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -284,7 +284,7 @@ message FunctionsMetadataRequest {
 // Worker sends function metadata back to host
 message FunctionMetadataResponse {
   // list of function indexing responses
-  repeated RpcFunctionMetadata function_load_requests_results = 1;
+  repeated RpcFunctionMetadata function_metadata_results = 1;
 
   // status of overall metadata request
   StatusResult result = 2;


### PR DESCRIPTION
Related issue - https://github.com/Azure/azure-functions-host/issues/7916

Adding useDefaultMetadataIndexing field to FunctionMetadataResponses to allow worker to deny indexing if it could not index and then host will perform the indexing.
