### PR TITLE
Edit streaming message types

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -78,7 +78,7 @@ message StreamingMessage {
 
     // Worker indexing message types
     FunctionsMetadataRequest functions_metadata_request = 29;
-    FunctionMetadataResponses function_metadata_responses = 30;
+    FunctionMetadataResponse function_metadata_response = 30;
   }
 }
 


### PR DESCRIPTION
Adding a change missed from [this Stein PR from yesterday](https://github.com/Azure/azure-functions-language-worker-protobuf/commit/18a91f6f72973ef3610cd985aa450f6fb4b7cf26). 

`FunctionMetadataResponses` was updated to `FunctionMetadataResponse` with no "s" and that change needed to be reflected  in the type `StreamingMessage`.