### PR TITLE
Adding new field to send a list of load requests in case of multiple functions

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -79,6 +79,9 @@ message StreamingMessage {
     // Worker indexing message types
     FunctionsMetadataRequest functions_metadata_request = 29;
     FunctionMetadataResponse function_metadata_response = 30;
+
+    // Host sends required metadata to worker to load functions
+    FunctionLoadRequests function_load_requests = 31;
   }
 }
 
@@ -220,7 +223,12 @@ message CloseSharedMemoryResourcesResponse {
   map<string, bool> close_map_results = 1;
 }
 
-// Host tells the worker to load a Function
+// Host tells the worker to load a list of Functions
+message FunctionLoadRequests {
+  repeated FunctionLoadRequest FunctionLoadRequest = 1;
+}
+
+// Load request of a single Function
 message FunctionLoadRequest {
   // unique function identifier (avoid name collisions, facilitate reload case)
   string function_id = 1;

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -81,7 +81,7 @@ message StreamingMessage {
     FunctionMetadataResponse function_metadata_response = 30;
 
     // Host sends required metadata to worker to load functions
-    FunctionLoadRequests function_load_requests = 31;
+    FunctionLoadRequestCollection function_load_request_collection = 31;
   }
 }
 
@@ -224,8 +224,8 @@ message CloseSharedMemoryResourcesResponse {
 }
 
 // Host tells the worker to load a list of Functions
-message FunctionLoadRequests {
-  repeated FunctionLoadRequest FunctionLoadRequest = 1;
+message FunctionLoadRequestCollection {
+  repeated FunctionLoadRequest function_load_requests = 1;
 }
 
 // Load request of a single Function


### PR DESCRIPTION
Issue - https://github.com/Azure/azure-functions-host/issues/7880

PR in Host - https://github.com/Azure/azure-functions-host/pull/8054

Host should have an ability to send a single FunctionLoadRequest in case of multiple functions in Function App.