### PR TITLE
Added fields to sync with host on RPCFunctionMetadata

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -273,6 +273,12 @@ message RpcFunctionMetadata {
 
   // Raw binding info
   repeated string raw_bindings = 10;
+
+  // unique function identifier (avoid name collisions, facilitate reload case)
+  string function_id = 13;
+
+  // A flag indicating if managed dependency is enabled or not
+  bool managed_dependency_enabled = 14;
 }
 
 // Host tells worker it is ready to receive metadata


### PR DESCRIPTION
Changes in host - https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.Grpc/azure-functions-language-worker-protobuf/src/proto/FunctionRpc.proto#:~:text=string%20config_source%20%3D%2012%3B-,//%20unique%20function%20identifier%20(avoid%20name%20collisions%2C%20facilitate%20reload%20case),bool%20managed_dependency_enabled%20%3D%2014%3B,-%7D