### PR TITLE
Change a field from camel case to underscores

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -304,7 +304,7 @@ message FunctionMetadataResponse {
   StatusResult result = 2;
 
   // if set to true then host will perform indexing
-  bool useDefaultMetadataIndexing = 3;
+  bool use_default_metadata_indexing = 3;
 }
 
 // Host requests worker to invoke a Function


### PR DESCRIPTION
Maintain consistency with field naming by using underscores rather than camel case