### PR TITLE
Adding field to allow worker to send list of load responses to host

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -82,6 +82,9 @@ message StreamingMessage {
 
     // Host sends required metadata to worker to load functions
     FunctionLoadRequestCollection function_load_request_collection = 31;
+
+    // Host gets the list of function load responses
+    FunctionLoadResponseCollection function_load_response_collection = 32;
   }
 }
 
@@ -226,6 +229,11 @@ message CloseSharedMemoryResourcesResponse {
 // Host tells the worker to load a list of Functions
 message FunctionLoadRequestCollection {
   repeated FunctionLoadRequest function_load_requests = 1;
+}
+
+// Host gets the list of function load responses
+message FunctionLoadResponseCollection {
+  repeated FunctionLoadResponse function_load_responses = 1;
 }
 
 // Load request of a single Function


### PR DESCRIPTION
Issue - https://github.com/Azure/azure-functions-host/issues/8082

Adding new field FunctionLoadResponseCollection to allow worker to send list of load responses to host. Worker can choose to send load responses one by one using FunctionLoadResponse or in batch using FunctionLoadResponseCollection.