### PR TITLE
Add function app dir to worker init request

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -113,6 +113,9 @@ message WorkerInitRequest {
 
   // Full path of worker.config.json location
   string worker_directory = 4;
+
+  // base directory for function app
+  string function_app_directory = 5;
 }
 
 // Worker responds with the result of initializing itself


### PR DESCRIPTION
There's been a few issues on the node worker where we want to adjust our behavior based on the user's package.json file (i.e. https://github.com/Azure/azure-functions-nodejs-worker/issues/531 and https://github.com/Azure/azure-functions-nodejs-worker/issues/522). I'm not aware of any way to get the function app dir unless we're using the worker indexing feature (aka `FunctionsMetadataRequest`), but that's still in preview and the linked issues feel more related to "initialization" vs "worker indexing" anyways.