### PR TITLE
Added fields to RpcException message for surfacing in AppInsights

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -553,6 +553,13 @@ message RpcException {
 
   // Textual message describing the exception
   string message = 2;
+
+  // Type of exception if thrown by user's function code 
+  optional string remote_type = 4; 
+
+  // Worker specifies whether exception is a user exception, 
+  // for purpose of application insights logging. 
+  optional bool is_end_user_exception = 5;
 }
 
 // Http cookie type. Note that only name and value are used for Http requests

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -548,9 +548,8 @@ message RpcException {
   // Source of the exception
   string source = 3;
 
-  // Stack trace for the exception. If it's a user code exception,
-  // worker should assign this value to the that exception's stack trace, 
-  // so that it can be passed along to app insights.  
+  // Stack trace for the exception. In case of system exception, worker should set to
+  // system exception's stack trace. In case of user exception, set to user exception's stack trace. 
   string stack_trace = 1;
 
   // Textual message describing the exception

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -548,8 +548,7 @@ message RpcException {
   // Source of the exception
   string source = 3;
 
-  // Stack trace for the exception. In case of system exception, worker should set to
-  // system exception's stack trace. In case of user exception, set to user exception's stack trace. 
+  // Stack trace for the exception
   string stack_trace = 1;
 
   // Textual message describing the exception

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -548,18 +548,21 @@ message RpcException {
   // Source of the exception
   string source = 3;
 
-  // Stack trace for the exception
+  // Stack trace for the exception. If it's a user code exception,
+  // worker should assign this value to the that exception's stack trace, 
+  // so that it can be passed along to app insights.  
   string stack_trace = 1;
 
   // Textual message describing the exception
   string message = 2;
 
-  // Type of exception if thrown by user's function code 
-  optional string remote_type = 4; 
-
   // Worker specifies whether exception is a user exception, 
-  // for purpose of application insights logging. 
-  optional bool is_user_exception = 5;
+  // for purpose of application insights logging. Defaults to false. 
+  optional bool is_user_exception = 4;
+
+  // Type of exception. If it's a user exception, the type is passed along to app insights.
+  // Otherwise, it's ignored for now.
+  optional string type = 5; 
 }
 
 // Http cookie type. Note that only name and value are used for Http requests

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -559,7 +559,7 @@ message RpcException {
 
   // Worker specifies whether exception is a user exception, 
   // for purpose of application insights logging. 
-  optional bool is_end_user_exception = 5;
+  optional bool is_user_exception = 5;
 }
 
 // Http cookie type. Note that only name and value are used for Http requests


### PR DESCRIPTION
Added the following fields for the scenario in which user code throws an exception: 

- exception type name
- bool for isUserException, to be set by each worker upon throwing the exception.

These were added so that the user code exception can be piped through to AI and avoid customer confusion. 