### PR TITLE
Change  RpcFunctionMetadata "Properties" field case

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -326,7 +326,7 @@ message RpcFunctionMetadata {
   // Properties for function metadata
   // They're usually specific to a worker and largely passed along to the controller API for use
   // outside the host
-   map<string,string> Properties = 16;
+   map<string,string> properties = 16;
 }
 
 // Host tells worker it is ready to receive metadata


### PR DESCRIPTION
All of the fields defined in our protobuf are snake_case, updating "Properties" field to match for consistency (as per the [style guide](https://developers.google.com/protocol-buffers/docs/style#message_and_field_names) we follow)

 By default proto3 JSON printer should convert the field name to lowerCamelCase and use that as the JSON name so I do not believe this is a breaking change, but if anyone else knows otherwise please let me know and I will abandon the PR/we can fix this in the next breaking change release