### PR TITLE
Add new message to support model-type bindings for OOP workers

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -32,7 +32,7 @@ message StreamingMessage {
     WorkerInitRequest worker_init_request = 17;
     // Worker responds after initializing with its capabilities & status
     WorkerInitResponse worker_init_response = 16;
-    
+
     // Worker periodically sends empty heartbeat message to host
     WorkerHeartbeat worker_heartbeat = 15;
 
@@ -429,6 +429,7 @@ message TypedData {
     CollectionString collection_string = 9;
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
+    BindingData bindingData = 12;
   }
 }
 
@@ -509,6 +510,7 @@ message BindingInfo {
       string = 1;
       binary = 2;
       stream = 3;
+      reference = 4;
     }
 
   // Type of binding (e.g. HttpTrigger)
@@ -582,13 +584,13 @@ message RpcException {
   // Textual message describing the exception
   string message = 2;
 
-  // Worker specifies whether exception is a user exception, 
-  // for purpose of application insights logging. Defaults to false. 
+  // Worker specifies whether exception is a user exception,
+  // for purpose of application insights logging. Defaults to false.
   bool is_user_exception = 4;
 
   // Type of exception. If it's a user exception, the type is passed along to app insights.
   // Otherwise, it's ignored for now.
-  string type = 5; 
+  string type = 5;
 }
 
 // Http cookie type. Note that only name and value are used for Http requests
@@ -646,4 +648,12 @@ message RpcHttp {
   map<string,NullableString> nullable_headers = 20;
   map<string,NullableString> nullable_params = 21;
   map<string,NullableString> nullable_query = 22;
+}
+
+message BindingData
+{
+    string Version = 1;
+    string ContentType = 2;
+    string Source = 3;
+    string Content = 4;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -188,7 +188,7 @@ message WorkerTerminate {
 message FileChangeEventRequest {
   // Types of File change operations (See link for more info: https://msdn.microsoft.com/en-us/library/t6xf43e0(v=vs.110).aspx)
   enum Type {
-	  Unknown = 0;
+    Unknown = 0;
     Created = 1;
     Deleted = 2;
     Changed = 4;
@@ -370,14 +370,14 @@ message InvocationRequest {
 
 // Host sends ActivityId, traceStateString and Tags from host
 message RpcTraceContext {
-	// This corresponds to Activity.Current?.Id
-	string trace_parent = 1;
+  // This corresponds to Activity.Current?.Id
+  string trace_parent = 1;
 
-	// This corresponds to Activity.Current?.TraceStateString
-	string trace_state = 2;
+  // This corresponds to Activity.Current?.TraceStateString
+  string trace_state = 2;
 
-	// This corresponds to Activity.Current?.Tags
-	map<string, string> attributes = 3;
+  // This corresponds to Activity.Current?.Tags
+  map<string, string> attributes = 3;
 }
 
 // Host sends retry context for a function invocation
@@ -430,7 +430,7 @@ message TypedData {
     CollectionString collection_string = 9;
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
-    BindingData binding_data = 12;
+    ModelBindingData model_binding_data = 12;
   }
 }
 
@@ -653,7 +653,7 @@ message RpcHttp {
 
 // Message representing Microsoft.Azure.WebJobs.ParameterBindingData
 // Used for hydrating SDK-type bindings in out-of-proc workers
-message BindingData
+message ModelBindingData
 {
     // The version of the binding data content
     string version = 1;

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -655,8 +655,15 @@ message RpcHttp {
 // Used for hydrating SDK-type bindings in out-of-proc workers
 message BindingData
 {
+    // The version of the binding data content
     string version = 1;
+
+    // The extension source of the binding data
     string source = 2;
+
+    // The binding data content
     string content_type = 3;
+
+    // The content type of the binding data content
     bytes content = 4;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -430,7 +430,7 @@ message TypedData {
     CollectionString collection_string = 9;
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
-    BindingData bindingData = 12;
+    BindingData binding_data = 12;
   }
 }
 
@@ -511,7 +511,7 @@ message BindingInfo {
       string = 1;
       binary = 2;
       stream = 3;
-      bindingData = 4;
+      binding_data = 4;
     }
 
   // Type of binding (e.g. HttpTrigger)
@@ -657,6 +657,6 @@ message BindingData
 {
     string version = 1;
     string source = 2;
-    string contentType = 3;
+    string content_type = 3;
     bytes content = 4;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -511,7 +511,7 @@ message BindingInfo {
       string = 1;
       binary = 2;
       stream = 3;
-      binding_data = 4;
+      model_binding_data = 4;
     }
 
   // Type of binding (e.g. HttpTrigger)

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -651,6 +651,8 @@ message RpcHttp {
   map<string,NullableString> nullable_query = 22;
 }
 
+// Message representing Microsoft.Azure.WebJobs.ParameterBindingData
+// Used for hydrating SDK-type bindings in out-of-proc workers
 message BindingData
 {
     string version = 1;

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -511,7 +511,7 @@ message BindingInfo {
       string = 1;
       binary = 2;
       stream = 3;
-      reference = 4;
+      bindingData = 4;
     }
 
   // Type of binding (e.g. HttpTrigger)
@@ -654,7 +654,7 @@ message RpcHttp {
 message BindingData
 {
     string Version = 1;
-    string ContentType = 2;
-    string Source = 3;
-    string Content = 4;
+    string Source = 2;
+    string ContentType = 3;
+    bytes Content = 4;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -498,21 +498,20 @@ message ParameterBinding {
 
 // Used to describe a given binding on load
 message BindingInfo {
-    // Indicates whether it is an input or output binding (or a fancy inout binding)
-    enum Direction {
-      in = 0;
-      out = 1;
-      inout = 2;
-    }
+  // Indicates whether it is an input or output binding (or a fancy inout binding)
+  enum Direction {
+    in = 0;
+    out = 1;
+    inout = 2;
+  }
 
-    // Indicates the type of the data for the binding
-    enum DataType {
-      undefined = 0;
-      string = 1;
-      binary = 2;
-      stream = 3;
-      model_binding_data = 4;
-    }
+  // Indicates the type of the data for the binding
+  enum DataType {
+    undefined = 0;
+    string = 1;
+    binary = 2;
+    stream = 3;
+  }
 
   // Type of binding (e.g. HttpTrigger)
   string type = 2;
@@ -521,6 +520,9 @@ message BindingInfo {
   Direction direction = 3;
 
   DataType data_type = 4;
+
+  // Properties for binding metadata
+  map<string, string> properties = 5;
 }
 
 // Used to send logs back to the Host

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -653,8 +653,8 @@ message RpcHttp {
 
 message BindingData
 {
-    string Version = 1;
-    string Source = 2;
-    string ContentType = 3;
-    bytes Content = 4;
+    string version = 1;
+    string source = 2;
+    string contentType = 3;
+    bytes content = 4;
 }

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -663,9 +663,9 @@ message ModelBindingData
     // The extension source of the binding data
     string source = 2;
 
-    // The binding data content
+    // The content type of the binding data content
     string content_type = 3;
 
-    // The content type of the binding data content
+    // The binding data content
     bytes content = 4;
 }


### PR DESCRIPTION
Related issue: https://github.com/Azure/azure-functions-dotnet-worker/issues/1035

A protobuf message for sending [ParameterBindingData](https://github.com/Azure/azure-webjobs-sdk/blob/7fbc0e6a9e629c01a728c0f7e38cae5130f7139a/src/Microsoft.Azure.WebJobs/ParameterBindingData.cs) from the host to the workers; this is used to hydrate SDK-type bindings.

- [Internal design doc for reference](https://dev.azure.com/msazure/One/_git/AAPT-Antares-Docs?path=/TeamDocs/FunctionTeamDocs/Design/OOPWorkers/SDKTypeBindings.md&version=GBmaster&_a=preview)
- [Usage of message in the host](https://github.com/Azure/azure-functions-host/blob/2d1af23fff17c2f7c2270d201a3abbeb8612372b/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs#L68-L84)
- [Usage of message in the worker](https://github.com/Azure/azure-functions-dotnet-worker/blob/5c174290c9ae37b0631ace40d34e1d045ed6c7cb/src/DotNetWorker.Grpc/Features/GrpcFunctionBindingsFeature.cs#L127)
