### PR TITLE
Worker code path warmup

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -86,6 +86,13 @@ message StreamingMessage {
 
     // Host gets the list of function load responses
     FunctionLoadResponseCollection function_load_response_collection = 32;
+    
+    // Host sends required metadata to worker to warmup the worker
+    WorkerWarmupRequest worker_warmup_request = 33;
+    
+    // Worker responds after warming up with the warmup result
+    WorkerWarmupResponse worker_warmup_response = 34;
+    
   }
 }
 
@@ -421,6 +428,15 @@ message InvocationResponse {
 
   // Status of the invocation (success/failure/canceled)
   StatusResult result = 3;
+}
+
+message WorkerWarmupRequest {
+  // Full path of worker.config.json location
+  string worker_directory = 1;
+}
+
+message WorkerWarmupResponse {
+  StatusResult result = 1;
 }
 
 // Used to encapsulate data which could be a variety of types


### PR DESCRIPTION
New protobuf message for warming up worker code path before specialization. 

- [Design doc](https://dev.azure.com/msazure/One/_git/AAPT-Antares-Docs/pullrequest/7030389?_a=files)
- [Draft host changes](https://github.com/Azure/azure-functions-host/pull/9018/files)
- [Draft Java worker changes](https://github.com/Azure/azure-functions-java-worker/pull/672/files)