### PR TITLE
Add new message to support collection of model-type bindings for OOP workers

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -431,6 +431,7 @@ message TypedData {
     CollectionDouble collection_double = 10;
     CollectionSInt64 collection_sint64 = 11;
     ModelBindingData model_binding_data = 12;
+    CollectionModelBindingData collection_model_binding_data = 13;
   }
 }
 
@@ -668,4 +669,9 @@ message ModelBindingData
 
     // The binding data content
     bytes content = 4;
+}
+
+// Used to encapsulate collection model_binding_data
+message CollectionModelBindingData {
+  repeated ModelBindingData model_binding_data = 1;
 }


### PR DESCRIPTION
Issue - https://github.com/Azure/azure-functions-dotnet-worker/issues/1156
Epic - https://github.com/Azure/azure-functions-dotnet-worker/issues/1081

A protobuf message for sending the collection of [ParameterBindingData](https://github.com/Azure/azure-webjobs-sdk/blob/7fbc0e6a9e629c01a728c0f7e38cae5130f7139a/src/Microsoft.Azure.WebJobs/ParameterBindingData.cs) from the host to the workers; this is used to hydrate SDK-type bindings.

Message for ModelBindingData - [Link](https://github.com/Azure/azure-functions-language-worker-protobuf/pull/83)
Usage in Host - [Link](https://github.com/Azure/azure-functions-host/blob/ba628f81c672a5ebdbafb9c0c8a65d3b174b68ee/src/WebJobs.Script.Grpc/MessageExtensions/GrpcMessageConversionExtensions.cs#L59)
Usage in Worker - [Link](https://github.com/Azure/azure-functions-dotnet-worker/blob/c55598bb3afa9c41b15a719c1a282c904057a5d9/extensions/Worker.Extensions.Storage.Blobs/src/BlobStorageConverter.cs#L25)