### PR TITLE
Add capabilities and worker_metadata in env reload response.

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -240,6 +240,13 @@ message FunctionEnvironmentReloadRequest {
 message FunctionEnvironmentReloadResponse {
   // Status of the response
   StatusResult result = 3;
+
+  // After specialization, worker sends capabilities & metadata.
+  // A map of worker supported features/capabilities
+  map<string, string> capabilities = 2;
+
+  // Worker metadata captured for telemetry purposes
+  WorkerMetadata worker_metadata = 1;
 }
 
 // Tell the out-of-proc worker to close any shared memory maps it allocated for given invocation

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -239,10 +239,10 @@ message FunctionEnvironmentReloadRequest {
 
 message FunctionEnvironmentReloadResponse {
   // After specialization, worker sends capabilities & metadata.
-  // A map of worker supported features/capabilities
+  // Worker metadata captured for telemetry purposes
   WorkerMetadata worker_metadata = 1;
 
-  // Worker metadata captured for telemetry purposes
+  // A map of worker supported features/capabilities
   map<string, string> capabilities = 2;
 
   // Status of the response

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -238,15 +238,15 @@ message FunctionEnvironmentReloadRequest {
 }
 
 message FunctionEnvironmentReloadResponse {
-  // Status of the response
-  StatusResult result = 3;
-
   // After specialization, worker sends capabilities & metadata.
   // A map of worker supported features/capabilities
-  map<string, string> capabilities = 2;
+  WorkerMetadata worker_metadata = 1;
 
   // Worker metadata captured for telemetry purposes
-  WorkerMetadata worker_metadata = 1;
+  map<string, string> capabilities = 2;
+
+  // Status of the response
+  StatusResult result = 3;
 }
 
 // Tell the out-of-proc worker to close any shared memory maps it allocated for given invocation


### PR DESCRIPTION
Add capabilities and worker metadata in env reload response. This is to support changes needed for https://github.com/Azure/azure-functions-host/issues/8983

Currently worker metadata and capabilities are sent in the worker init response. But this is not valid for placeholder & specialization use case. When in placeholder mode, this information is not available. It is available only after specialization (env reload request). So we need to include this information in the env reload response.

I added 1 and 2 as the order for these new props as the existing `result` property(the only property existed in this type) was using 3. I looked at this history of this and found that PR #20  added this type and status property. This type never had a property with order value 1 and 2. So I am guessing this will not break anything.