### PR TITLE
Add capabilities update strategy to environment reload response

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -248,10 +248,8 @@ message FunctionEnvironmentReloadResponse {
   enum CapabilitiesUpdateStrategy {
     // overwrites existing values and appends
     merge = 0;
-    // appends, skipping existing items
-    union = 1;
     // existing capabilities are cleared and new capabilities are applied
-    replace = 2;
+    replace = 1;
   }
   // After specialization, worker sends capabilities & metadata.
   // Worker metadata captured for telemetry purposes

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -246,8 +246,12 @@ message FunctionEnvironmentReloadRequest {
 
 message FunctionEnvironmentReloadResponse {
   enum CapabilitiesUpdateStrategy {
+    // overwrites existing values and appends
     merge = 0;
-    override = 1;
+    // appends, skipping existing items
+    union = 1;
+    // new capabilities are applied
+    replace = 2;
   }
   // After specialization, worker sends capabilities & metadata.
   // Worker metadata captured for telemetry purposes

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -246,7 +246,7 @@ message FunctionEnvironmentReloadRequest {
 
 message FunctionEnvironmentReloadResponse {
   enum CapabilitiesUpdateStrategy {
-    // overwrites existing values and appends
+    // overwrites existing values and appends new ones
     merge = 0;
     // existing capabilities are cleared and new capabilities are applied
     replace = 1;

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -250,7 +250,7 @@ message FunctionEnvironmentReloadResponse {
     merge = 0;
     // appends, skipping existing items
     union = 1;
-    // new capabilities are applied
+    // existing capabilities are cleared and new capabilities are applied
     replace = 2;
   }
   // After specialization, worker sends capabilities & metadata.

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -247,8 +247,10 @@ message FunctionEnvironmentReloadRequest {
 message FunctionEnvironmentReloadResponse {
   enum CapabilitiesUpdateStrategy {
     // overwrites existing values and appends new ones
+    // ex. worker init: {A: foo, B: bar} + env reload: {A:foo, B: foo, C: foo} -> {A: foo, B: foo, C: foo}
     merge = 0;
     // existing capabilities are cleared and new capabilities are applied
+    // ex. worker init: {A: foo, B: bar} + env reload: {A:foo, C: foo} -> {A: foo, C: foo}
     replace = 1;
   }
   // After specialization, worker sends capabilities & metadata.
@@ -260,7 +262,8 @@ message FunctionEnvironmentReloadResponse {
 
   // Status of the response
   StatusResult result = 3;
-
+  
+  // If no strategy is defined, the host will default to merge
   CapabilitiesUpdateStrategy capabilities_update_strategy = 4;
 }
 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -245,6 +245,10 @@ message FunctionEnvironmentReloadRequest {
 }
 
 message FunctionEnvironmentReloadResponse {
+  enum CapabilitiesUpdateStrategy {
+    merge = 0;
+    override = 1;
+  }
   // After specialization, worker sends capabilities & metadata.
   // Worker metadata captured for telemetry purposes
   WorkerMetadata worker_metadata = 1;
@@ -254,6 +258,8 @@ message FunctionEnvironmentReloadResponse {
 
   // Status of the response
   StatusResult result = 3;
+
+  CapabilitiesUpdateStrategy capabilities_update_strategy = 4;
 }
 
 // Tell the out-of-proc worker to close any shared memory maps it allocated for given invocation


### PR DESCRIPTION
Even though updated capabilities are sent in an environment reload response, they are not always applied correctly (Related host PR: https://github.com/Azure/azure-functions-host/pull/9367). Furthermore, there may be cases where we need different strategies for applying capabilities. Some examples from @brettsam:

1. In placeholder mode, worker tell us capability A, B, C. when specialized, it sends us nothing ([python example]( https://github.com/Azure/azure-functions-python-worker/blob/6872fc088ca3ad00dc1a24aca9e6e044caa7af3a/azure_functions_worker/dispatcher.py#L587C4-L587C4)). We should just leave A, B, C -- otherwise we would break the worker.
2. In placeholder mode, worker tell us capability A, B, C. When specialized, it sends us A, B, D. Today we'd make this A, B, C, D -- but should it be A, B, D? 

This PR adds a property to the environment reload response message indicating to the host which strategy to use when receiving updated capabilities from a worker. 