### PR TITLE
Settlement Proto for Service Bus to Support Service Bus Message Actions

### DIFF
--- a/src/proto/servicebus/settlement.proto
+++ b/src/proto/servicebus/settlement.proto
@@ -1,0 +1,99 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
+import "google/protobuf/timestamp.proto";
+
+// this namespace will be shared between isolated worker and WebJobs extension so make it somewhat generic
+option csharp_namespace = "Microsoft.Azure.ServiceBus.Grpc";
+
+// The settlement service definition.
+service Settlement {
+  // Completes a message
+  rpc Complete (CompleteRequest) returns (google.protobuf.Empty) {}
+
+  // Abandons a message
+  rpc Abandon (AbandonRequest) returns (google.protobuf.Empty) {}
+
+  // Deadletters a message
+  rpc Deadletter (DeadletterRequest) returns (google.protobuf.Empty) {}
+
+  // Defers a message
+  rpc Defer (DeferRequest) returns (google.protobuf.Empty) {}
+
+  // Renew message lock
+  rpc RenewMessageLock (RenewMessageLockRequest) returns (google.protobuf.Empty) {}
+
+  // Get session state
+  rpc GetSessionState (GetSessionStateRequest) returns (GetSessionStateResponse) {}
+
+  // Set session state
+  rpc SetSessionState (SetSessionStateRequest) returns (google.protobuf.Empty) {}
+
+  // Release session
+  rpc ReleaseSession (ReleaseSessionRequest) returns (google.protobuf.Empty) {}
+
+  // Renew session lock
+  rpc RenewSessionLock (RenewSessionLockRequest) returns (RenewSessionLockResponse) {}
+}
+
+// The complete message request containing the locktoken.
+message CompleteRequest {
+  string locktoken = 1;
+}
+
+// The abandon message request containing the locktoken and properties to modify.
+message AbandonRequest {
+  string locktoken = 1;
+  bytes propertiesToModify = 2;
+}
+
+// The deadletter message request containing the locktoken and properties to modify along with the reason/description.
+message DeadletterRequest {
+  string locktoken = 1;
+  bytes propertiesToModify = 2;
+  google.protobuf.StringValue deadletterReason = 3;
+  google.protobuf.StringValue deadletterErrorDescription = 4;
+}
+
+// The defer message request containing the locktoken and properties to modify.
+message DeferRequest {
+  string locktoken = 1;
+  bytes propertiesToModify = 2;
+}
+
+// The renew message lock request containing the locktoken.
+message RenewMessageLockRequest {
+  string locktoken = 1;
+}
+
+// The get message request.
+message GetSessionStateRequest {
+  string sessionId = 1;
+}
+
+// The set message request.
+message SetSessionStateRequest {
+  string sessionId = 1;
+  bytes sessionState = 2;
+}
+
+// Get response containing the session state.
+message GetSessionStateResponse {
+  bytes sessionState = 1;
+}
+
+// Release session.
+message ReleaseSessionRequest {
+  string sessionId = 1;
+}
+
+// Renew session lock.
+message RenewSessionLockRequest {
+  string sessionId = 1;
+}
+
+// Renew session lock.
+message RenewSessionLockResponse {
+  google.protobuf.Timestamp lockedUntil = 1;
+}


### PR DESCRIPTION
### Description:
This PR adds the settlement.proto definition file, which is required to support gRPC-based Service Bus message actions such as Complete, Abandon, Defer, and DeadLetter. This is part of enabling message settlement capabilities in the new Service Bus extension layer.

### Key Changes:

Introduced settlement.proto under the proto definitions directory.
This file defines the contract for performing message actions over gRPC.

This feature has been in development for non-.NET environments. However, it has already been available and well-tested in .NET for the past two years.
I am currently working on implementing this feature for Node.js.

 
[Adding ServiceBus Trigger Chnages by swapnil-nagar · Pull Request #353 · Azure/azure-functions-nodejs-library](https://github.com/Azure/azure-functions-nodejs-library/pull/353)
[Azure Functions Service Bus Extensions with Message Settlement by swapnil-nagar · Pull Request #4 · Azure/azure-functions-nodejs-extensions](https://github.com/Azure/azure-functions-nodejs-extensions/pull/4)

**Existing proto contract with dotNet env.**

[azure-functions-dotnet-worker/extensions/Worker.Extensions.ServiceBus/src/Proto/settlement.proto at 37484db97f9acf45d198550a9ee61e721d90178c · Azure/azure-functions-dotnet-worker](https://github.com/Azure/azure-functions-dotnet-worker/blob/37484db97f9acf45d198550a9ee61e721d90178c/extensions/Worker.Extensions.ServiceBus/src/Proto/settlement.proto)