### PR TITLE
Add RpcTraceContext to InvocationResponse

### DIFF
--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -442,6 +442,11 @@ message InvocationResponse {
 
   // Status of the invocation (success/failure/canceled)
   StatusResult result = 3;
+
+  // Reuses values from InvocationRequest with some additions to the attributes field
+  // Enables propagation of tags from worker -> host.
+  RpcTraceContext trace_context = 4;
+
 }
 
 message WorkerWarmupRequest {

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -443,9 +443,8 @@ message InvocationResponse {
   // Status of the invocation (success/failure/canceled)
   StatusResult result = 3;
 
-  // Reuses values from InvocationRequest with some additions to the attributes field
   // Enables propagation of tags from worker -> host.
-  RpcTraceContext trace_context = 4;
+  map<string, string> trace_context_attributes = 4;
 
 }
 

--- a/src/proto/FunctionRpc.proto
+++ b/src/proto/FunctionRpc.proto
@@ -437,14 +437,14 @@ message InvocationResponse {
   // Output binding data
   repeated ParameterBinding output_data = 2;
 
-  // data returned from Function (for $return and triggers with return support)
-  TypedData return_value = 4;
-
   // Status of the invocation (success/failure/canceled)
   StatusResult result = 3;
 
+  // data returned from Function (for $return and triggers with return support)
+  TypedData return_value = 4;
+
   // Enables propagation of tags from worker -> host.
-  map<string, string> trace_context_attributes = 4;
+  map<string, string> trace_context_attributes = 5;
 
 }
 


### PR DESCRIPTION
Related to: https://github.com/Azure/azure-functions-host/issues/11397

Similar to [InvocationRequest](https://github.com/Azure/azure-functions-language-worker-protobuf/blob/51a2d1799679145583923e5d8d1ef78f9521623e/src/proto/FunctionRpc.proto#L393), this augments InvocationResponse and adds a field to collect TraceContext attributes (represented as `map<string, string>`). This allows propagation of attributes from worker to the host.